### PR TITLE
fix(ci): install node_modules before fallow so tsconfig aliases resolve

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           fetch-depth: 0          # required for --changed-since / trend tracking
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+        # Required so Fallow can resolve tsconfig.json `extends: astro/tsconfigs/strict`
+        # and follow the full path-alias chain (@components/*, @lib/*, @/*, etc.)
+
       - uses: fallow-rs/fallow@v2
         with:
           format: sarif


### PR DESCRIPTION
fallow reads tsconfig.json to resolve path aliases (@components/*, @lib/*, @/*, etc.). the tsconfig extends astro/tsconfigs/strict which lives in node_modules. without npm ci running first, fallow cannot follow the extends chain and falls back to no alias resolution, producing ~80 false-positive unresolved-import errors and ~47 cascade unused-file warnings (127 of the 185 open Code Scanning alerts).