### PR TITLE
fix(deps): remove unused packages and suppress config-consumed false positives

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -39,7 +39,22 @@
     "@astrojs/sitemap",
     "@astrojs/vercel",
     "astro-icon",
-    "astro-seo"
+    "astro-seo",
+    "@tailwindcss/typography",
+    "@tailwindcss/vite",
+    "@typescript-eslint/eslint-plugin",
+    "@typescript-eslint/parser",
+    "@textlint/markdown-to-ast",
+    "eslint-plugin-mdx",
+    "textlint-filter-rule-comments",
+    "textlint-rule-alex",
+    "textlint-rule-common-misspellings",
+    "textlint-rule-en-capitalization",
+    "textlint-rule-terminology",
+    "textlint-rule-write-good",
+    "lighthouse",
+    "react-email",
+    "web-vitals"
   ],
   "rules": {
     "unused-files": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,16 +27,13 @@
         "astro-icon": "^1.1.5",
         "astro-seo": "^0.8.4",
         "clsx": "2.1.1",
-        "formik": "^2.4.6",
-        "framer-motion": "^12.23.7",
         "markdown-it": "^14.1.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "resend": "^4.7.0",
         "sanitize-html": "^2.17.0",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss": "^4.1.18",
-        "yup": "^1.6.1"
+        "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.7",
@@ -45,8 +42,6 @@
         "@eslint/js": "^9.31.0",
         "@iconify-json/ic": "^1.2.2",
         "@iconify-json/jam": "^1.2.3",
-        "@iconify-json/mdi": "^1.2.3",
-        "@iconify-json/meteocons": "^1.2.2",
         "@textlint/markdown-to-ast": "^15.2.1",
         "@types/jsdom": "^21.1.7",
         "@types/markdown-it": "^14.1.2",
@@ -3515,26 +3510,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@iconify-json/jam/-/jam-1.2.3.tgz",
       "integrity": "sha512-Kp+OxTzB8xvbaMyIoqEqB96Ik4zv7uo5y1yavjAee0N1K/6u+PCOBwEi+Djn3WJ2trCrNZk+qYw1BJUsZC41Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@iconify/types": "*"
-      }
-    },
-    "node_modules/@iconify-json/mdi": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
-      "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@iconify/types": "*"
-      }
-    },
-    "node_modules/@iconify-json/meteocons": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@iconify-json/meteocons/-/meteocons-1.2.4.tgz",
-      "integrity": "sha512-E7YV02ql5WmJgAOpXU/hoF9Mdshq73KjwR6fBxZ5SrqMJghMa3CIcRG6NQGwP4I1uBOhIjOFlAikYoPAKuT56A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7689,18 +7664,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -14005,15 +13968,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/default-browser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
@@ -18815,31 +18769,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/formik": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.9.tgz",
-      "integrity": "sha512-5nI94BMnlFDdQRBY4Sz39WkhxajZJ57Fzs8wVbtsQlm5ScKIR1QLYqv/ultBnobObtlUyxpxoLodpixrsf36Og==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://opencollective.com/formik"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "deepmerge": "^2.1.1",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "react-fast-compare": "^2.0.1",
-        "tiny-warning": "^1.0.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -18856,33 +18785,6 @@
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/framer-motion": {
-      "version": "12.27.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.27.1.tgz",
-      "integrity": "sha512-cEAqO69kcZt3gL0TGua8WTgRQfv4J57nqt1zxHtLKwYhAwA0x9kDS/JbMa1hJbwkGY74AGJKvZ9pX/IqWZtZWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.27.1",
-        "motion-utils": "^12.24.10",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "node_modules/fresh": {
       "version": "2.0.0",
@@ -20141,15 +20043,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/hono": {
@@ -22198,6 +22091,7 @@
       "version": "4.17.22",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
       "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -25195,21 +25089,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/motion-dom": {
-      "version": "12.27.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.27.1.tgz",
-      "integrity": "sha512-V/53DA2nBqKl9O2PMJleSUb/G0dsMMeZplZwgIQf5+X0bxIu7Q1cTv6DrjvTTGYRm3+7Y5wMlRZ1wT61boU/bQ==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.24.10"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.24.10",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.24.10.tgz",
-      "integrity": "sha512-x5TFgkCIP4pPsRLpKoI86jv/q8t8FQOiM/0E8QKBzfMozWHfkKap2gA1hOki+B5g3IsBNpxbUnfOum1+dgvYww==",
-      "license": "MIT"
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -27200,12 +27079,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/property-expr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
-      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
-      "license": "MIT"
-    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -27736,18 +27609,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
-      "license": "MIT"
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-promise-suspense": {
       "version": "0.3.4",
@@ -31754,22 +31615,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tiny-case": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
-      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
-      "license": "MIT"
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -31998,12 +31847,6 @@
         "npm": ">=5"
       }
     },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
-      "license": "MIT"
-    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -32133,6 +31976,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -35656,30 +35500,6 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
-    },
-    "node_modules/yup": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
-      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
-      "license": "MIT",
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/yup/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -80,16 +80,13 @@
     "astro-icon": "^1.1.5",
     "astro-seo": "^0.8.4",
     "clsx": "2.1.1",
-    "formik": "^2.4.6",
-    "framer-motion": "^12.23.7",
     "markdown-it": "^14.1.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "resend": "^4.7.0",
     "sanitize-html": "^2.17.0",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.1.18",
-    "yup": "^1.6.1"
+    "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.7",
@@ -98,8 +95,6 @@
     "@eslint/js": "^9.31.0",
     "@iconify-json/ic": "^1.2.2",
     "@iconify-json/jam": "^1.2.3",
-    "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/meteocons": "^1.2.2",
     "@textlint/markdown-to-ast": "^15.2.1",
     "@types/jsdom": "^21.1.7",
     "@types/markdown-it": "^14.1.2",


### PR DESCRIPTION
## Tier 1 tech debt cleanup — package.json and .fallowrc.json

### Remove unused production dependencies
- formik + yup: form library replaced by custom useContactForm hook
- framer-motion: never imported anywhere in the codebase

### Remove unused dev dependencies (icon sets)
- @iconify-json/mdi: no mdi: icons used in any template
- @iconify-json/meteocons: no meteocons: icons used in any template
- (@iconify-json/ic and @iconify-json/jam are kept - actively used in Pagination.astro and index.astro)

### Add ignoreDependencies for config-consumed packages
Fallow detects usage via JS imports only. These packages are real dependencies consumed via config files that Fallow cannot see:
- @tailwindcss/typography: loaded via @plugin in src/styles/global.css
- @tailwindcss/vite: loaded via vite config
- @typescript-eslint/eslint-plugin + parser: used in config/eslint.config.js
- eslint-plugin-mdx: used in config/eslint.config.js
- textlint-* rules + @textlint/markdown-to-ast: declared in config/.textlintrc.json
- lighthouse, react-email, web-vitals: CLI tools invoked by test scripts, not imported

### Expected alert reduction
From 54 open alerts to ~30 (clears all unused-dependency and most unused-dev-dependency alerts).