### PR TITLE
fix(deps): restore @iconify-json/mdi removed in error

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -40,6 +40,7 @@
     "@astrojs/vercel",
     "astro-icon",
     "astro-seo",
+    "@iconify-json/mdi",
     "@tailwindcss/typography",
     "@tailwindcss/vite",
     "@typescript-eslint/eslint-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@eslint/js": "^9.31.0",
         "@iconify-json/ic": "^1.2.2",
         "@iconify-json/jam": "^1.2.3",
+        "@iconify-json/mdi": "1.2.3",
         "@textlint/markdown-to-ast": "^15.2.1",
         "@types/jsdom": "^21.1.7",
         "@types/markdown-it": "^14.1.2",
@@ -3512,6 +3513,16 @@
       "integrity": "sha512-Kp+OxTzB8xvbaMyIoqEqB96Ik4zv7uo5y1yavjAee0N1K/6u+PCOBwEi+Djn3WJ2trCrNZk+qYw1BJUsZC41Eg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/mdi": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
+      "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@eslint/js": "^9.31.0",
     "@iconify-json/ic": "^1.2.2",
     "@iconify-json/jam": "^1.2.3",
+    "@iconify-json/mdi": "1.2.3",
     "@textlint/markdown-to-ast": "^15.2.1",
     "@types/jsdom": "^21.1.7",
     "@types/markdown-it": "^14.1.2",


### PR DESCRIPTION
mdi: icons are used in src/data/navData.ts:15,29,35 as string values (icon: 'mdi:link-variant', icon: 'mdi:account-group'). the grep in PR #59 only searched template attributes (icon="mdi:...") and missed this pattern, so @iconify-json/mdi was incorrectly removed, breaking the Vercel build with 'Unable to locate the mdi icon set'. also adds mdi to ignoreDependencies in .fallowrc.json so fallow does not flag it again.