### PR TITLE
fix(fallow): add ic and jam iconify sets to ignoredependencies

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -40,6 +40,8 @@
     "@astrojs/vercel",
     "astro-icon",
     "astro-seo",
+    "@iconify-json/ic",
+    "@iconify-json/jam",
     "@iconify-json/mdi",
     "@tailwindcss/typography",
     "@tailwindcss/vite",


### PR DESCRIPTION
ic and jam iconify sets were added to ignoreDependencies on the hotfix branch but the commit landed after PR #60 squash-merged, so it was lost. these two sets are used as string values in Pagination.astro and index.astro — not JS imports — so fallow cannot detect them.