### PR TITLE
refactor(admin): remove redundant logout button from /admin/clients

### DIFF
--- a/src/pages/admin/clients.astro
+++ b/src/pages/admin/clients.astro
@@ -1,7 +1,8 @@
 ---
-import Layout from '@layouts/index.astro'
 import AdminClientsManager from '@components/Admin/AdminClientsManager'
+import Layout from '@layouts/index.astro'
 import { db } from '@lib/db'
+
 import { clients } from '@/db/schema'
 
 const allClients = await db
@@ -20,47 +21,23 @@ const allClients = await db
 <Layout title="Admin — Clients">
 	<div class="min-h-screen bg-white dark:bg-gray-900">
 		<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-			<div class="mb-8 flex items-center justify-between">
-				<div>
-					<div class="flex items-center gap-3">
-						<a
-							href="/admin"
-							class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
-							← Admin
-						</a>
-						<h1 class="text-3xl font-bold text-gray-900 dark:text-white">
-							Clients
-						</h1>
-					</div>
-					<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-						Manage client accounts, files, and portal access
-					</p>
+			<div class="mb-8">
+				<div class="flex items-center gap-3">
+					<a
+						href="/admin"
+						class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+						← Admin
+					</a>
+					<h1 class="text-3xl font-bold text-gray-900 dark:text-white">
+						Clients
+					</h1>
 				</div>
-				<button
-					id="logout-btn"
-					class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700">
-					Logout
-				</button>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Manage client accounts, files, and portal access
+				</p>
 			</div>
 
 			<AdminClientsManager initialClients={allClients} client:load />
 		</div>
 	</div>
-
-	<script>
-		document.addEventListener('astro:page-load', () => {
-			document.getElementById('logout-btn')?.addEventListener('click', async () => {
-				try {
-					await fetch('/api/auth.json', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ action: 'logout' }),
-						credentials: 'include',
-					})
-				} finally {
-					window.location.href = '/admin/login'
-				}
-			})
-		})
-	</script>
 </Layout>


### PR DESCRIPTION
Logout now lives only in the global header (consistent with the dashboard and the other admin pages). Removes the per-page logout button on `/admin/clients` and its dead handler script; simplifies the now-single-child flex header.

No DB or behavior change — logout is still available from the header on every admin page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)