### PR TITLE
fix(client-portal): private blob access + presigned download URLs

### DIFF
--- a/src/pages/api/admin/client-files.json.ts
+++ b/src/pages/api/admin/client-files.json.ts
@@ -78,7 +78,9 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 
 			const blobKey = `clients/${clientId}/${Date.now()}-${file.name}`
 			const blob = await put(blobKey, file, {
-				access: 'public',
+				// Private: client documents are confidential. Downloads are served
+				// via short-lived presigned URLs (see api/client/files.json.ts).
+				access: 'private',
 				token: import.meta.env.BLOB_READ_WRITE_TOKEN,
 				oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
 				storeId: import.meta.env.BLOB_STORE_ID,

--- a/src/pages/api/client/files.json.ts
+++ b/src/pages/api/client/files.json.ts
@@ -1,14 +1,14 @@
-import { db } from '@lib/db'
 import { requireClientSession } from '@lib/clientSession'
+import { db } from '@lib/db'
 import {
 	createErrorResponse,
 	createSuccessResponse,
 	UnauthorizedError,
 	ValidationError,
 } from '@lib/errors'
+import { head, issueSignedToken, presignUrl } from '@vercel/blob'
 import type { APIRoute } from 'astro'
 import { and, eq } from 'drizzle-orm'
-import { head } from '@vercel/blob'
 
 import { clientNodes } from '@/db/schema'
 
@@ -46,16 +46,29 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
 			throw new ValidationError('Node is not a downloadable file')
 		}
 
-		// Generate a short-lived signed URL via Vercel Blob
-		const blobInfo = await head(node.blobKey, {
+		// The store is private, so the blob URL isn't directly accessible.
+		// Issue a short-lived (1h) presigned GET URL scoped to this one file.
+		const blobAuth = {
 			token: import.meta.env.BLOB_READ_WRITE_TOKEN,
 			oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
 			storeId: import.meta.env.BLOB_STORE_ID,
+		}
+
+		const { pathname } = await head(node.blobKey, blobAuth)
+
+		const signedToken = await issueSignedToken({
+			...blobAuth,
+			pathname,
+			operations: ['get'],
+			validUntil: Date.now() + 60 * 60 * 1000,
+		})
+		const { presignedUrl } = await presignUrl(signedToken, {
+			operation: 'get',
+			pathname,
+			access: 'private',
 		})
 
-		// The URL from head() is already the public URL; for signed/private blobs
-		// we return it directly — Vercel Blob private access is enforced via the token
-		return createSuccessResponse({ url: blobInfo.url, name: node.name })
+		return createSuccessResponse({ url: presignedUrl, name: node.name })
 	} catch (error) {
 		console.error('[client-files] error:', error)
 		return createErrorResponse(error)


### PR DESCRIPTION
## Problem
Uploading a client file in prod failed: **"Vercel Blob: Cannot use public access on a private store."** The Blob store is configured **private** (client documents are confidential — matches the intended design), but the upload code requested `access: 'public'`.

## Fix (code, not Vercel config — the private store is correct)
- **Upload** (`api/admin/client-files.json.ts`): `access: 'public'` → `'private'`.
- **Download** (`api/client/files.json.ts`): the previous code returned the raw blob URL with a comment admitting it assumed public access. Now it issues a **short-lived (1h) presigned GET URL** scoped to the single file via `issueSignedToken` + `presignUrl`.

## Verification
- `astro check` (types) ✅, build ✅, eslint ✅.
- ⚠️ **Runtime needs a Preview/Prod check** — private-blob presigning depends on Vercel OIDC + the private store, which can't be exercised locally. The PR's Vercel Preview deploy is where to confirm: upload a file to a client, then download it as that client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)