### PR TITLE
fix(blob): resolve credentials from process.env at runtime

### DIFF
--- a/src/lib/blob.ts
+++ b/src/lib/blob.ts
@@ -1,0 +1,32 @@
+// Vercel Blob credential resolution.
+//
+// The store is private, so every operation needs valid credentials. On Vercel
+// the per-request `VERCEL_OIDC_TOKEN` is injected into `process.env` at
+// runtime — but Astro resolves `import.meta.env` at *build* time, so reading
+// the OIDC token from `import.meta.env` yields a stale/empty value and the API
+// rejects it with "Access denied". Prefer `process.env` (runtime) and fall
+// back to `import.meta.env` for local dev (.env.local).
+function fromEnv(
+	processValue: string | undefined,
+	buildValue: string | undefined,
+): string | undefined {
+	return processValue ?? buildValue
+}
+
+export function blobAuth(): {
+	token?: string
+	oidcToken?: string
+	storeId?: string
+} {
+	return {
+		token: fromEnv(
+			process.env.BLOB_READ_WRITE_TOKEN,
+			import.meta.env.BLOB_READ_WRITE_TOKEN,
+		),
+		oidcToken: fromEnv(
+			process.env.VERCEL_OIDC_TOKEN,
+			import.meta.env.VERCEL_OIDC_TOKEN,
+		),
+		storeId: fromEnv(process.env.BLOB_STORE_ID, import.meta.env.BLOB_STORE_ID),
+	}
+}

--- a/src/lib/clientFiles.ts
+++ b/src/lib/clientFiles.ts
@@ -1,22 +1,15 @@
+import { blobAuth } from '@lib/blob'
 import { db } from '@lib/db'
 import { del } from '@vercel/blob'
 import { and, eq } from 'drizzle-orm'
 
 import { clientNodes } from '@/db/schema'
 
-function blobOptions() {
-	return {
-		token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-		oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-		storeId: import.meta.env.BLOB_STORE_ID,
-	}
-}
-
 // Best-effort blob deletion: a storage failure must not orphan DB rows, so we
 // log and continue rather than throw.
 async function deleteBlob(blobKey: string): Promise<void> {
 	try {
-		await del(blobKey, blobOptions())
+		await del(blobKey, blobAuth())
 	} catch (error) {
 		console.error('[clientFiles] blob delete failed:', blobKey, error)
 	}

--- a/src/pages/api/admin/client-files.json.ts
+++ b/src/pages/api/admin/client-files.json.ts
@@ -1,3 +1,4 @@
+import { blobAuth } from '@lib/blob'
 import { deleteNodeRecursive } from '@lib/clientFiles'
 import { db } from '@lib/db'
 import {
@@ -81,9 +82,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 				// Private: client documents are confidential. Downloads are served
 				// via short-lived presigned URLs (see api/client/files.json.ts).
 				access: 'private',
-				token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-				oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-				storeId: import.meta.env.BLOB_STORE_ID,
+				...blobAuth(),
 				addRandomSuffix: false,
 			})
 

--- a/src/pages/api/client/files.json.ts
+++ b/src/pages/api/client/files.json.ts
@@ -1,3 +1,4 @@
+import { blobAuth } from '@lib/blob'
 import { requireClientSession } from '@lib/clientSession'
 import { db } from '@lib/db'
 import {
@@ -48,16 +49,12 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
 
 		// The store is private, so the blob URL isn't directly accessible.
 		// Issue a short-lived (1h) presigned GET URL scoped to this one file.
-		const blobAuth = {
-			token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-			oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-			storeId: import.meta.env.BLOB_STORE_ID,
-		}
+		const auth = blobAuth()
 
-		const { pathname } = await head(node.blobKey, blobAuth)
+		const { pathname } = await head(node.blobKey, auth)
 
 		const signedToken = await issueSignedToken({
-			...blobAuth,
+			...auth,
 			pathname,
 			operations: ['get'],
 			validUntil: Date.now() + 60 * 60 * 1000,


### PR DESCRIPTION
## Problem
Uploading a client file still failed in prod: **"Vercel Blob: Access denied, please provide a valid token for this resource."** (The earlier private-access fix got us past the public/private error; this is the next layer.)

## Root cause
Blob credentials were read via `import.meta.env`, which Astro resolves at **build** time. But `VERCEL_OIDC_TOKEN` is injected **fresh per request** into `process.env` at runtime — so `import.meta.env.VERCEL_OIDC_TOKEN` was stale/empty and the private store rejected the request.

## Fix
New `src/lib/blob.ts` → `blobAuth()` reads credentials from `process.env` first (runtime), falling back to `import.meta.env` (local `.env.local`). Used by `put` / `del` / `head` / `issueSignedToken`.

## Verification
- `astro check` ✅, build ✅, eslint ✅.
- ⚠️ Runtime auth can only be validated on Vercel — needs a prod test: upload a file to a client, then download it as that client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)