### PR TITLE
Fix/blob runtime auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
 			"hasInstallScript": true,
 			"dependencies": {
 				"@astrojs/db": "^0.21.3",
-				"@astrojs/mdx": "^7.0.0",
+				"@astrojs/mdx": "^7.0.3",
 				"@astrojs/partytown": "^2.1.7",
-				"@astrojs/react": "^6.0.0",
+				"@astrojs/react": "^6.0.1",
 				"@astrojs/rss": "^4.0.18",
 				"@astrojs/sitemap": "^3.7.3",
 				"@astrojs/vercel": "^11.0.0",
@@ -26,7 +26,7 @@
 				"@vercel/blob": "^2.4.1",
 				"@vercel/og": "^0.8.6",
 				"@vercel/speed-insights": "^2.0.0",
-				"astro": "^7.0.2",
+				"astro": "^7.1.2",
 				"astro-icon": "^1.1.5",
 				"astro-seo": "^0.8.4",
 				"drizzle-orm": "^0.45.2",
@@ -155,29 +155,29 @@
 			"license": "MIT"
 		},
 		"node_modules/@astrojs/compiler-binding": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.2.2.tgz",
-			"integrity": "sha512-PkCo+UcSxMt9pufjv28kRy8YU88O/XNgm7apwkyhkrCecLY62QCj5UA3nOTMO88PPyVKnUh/6FZbPefBhDD5IA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
+			"integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@astrojs/compiler-binding-darwin-arm64": "0.2.2",
-				"@astrojs/compiler-binding-darwin-x64": "0.2.2",
-				"@astrojs/compiler-binding-linux-arm64-gnu": "0.2.2",
-				"@astrojs/compiler-binding-linux-arm64-musl": "0.2.2",
-				"@astrojs/compiler-binding-linux-x64-gnu": "0.2.2",
-				"@astrojs/compiler-binding-linux-x64-musl": "0.2.2",
-				"@astrojs/compiler-binding-wasm32-wasi": "0.2.2",
-				"@astrojs/compiler-binding-win32-arm64-msvc": "0.2.2",
-				"@astrojs/compiler-binding-win32-x64-msvc": "0.2.2"
+				"@astrojs/compiler-binding-darwin-arm64": "0.3.1",
+				"@astrojs/compiler-binding-darwin-x64": "0.3.1",
+				"@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
+				"@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
+				"@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
+				"@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
+				"@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
+				"@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
+				"@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-darwin-arm64": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.2.2.tgz",
-			"integrity": "sha512-1WxpECx3izz5X4Ha3l6ex79HZlUHpKBTElGJsfOosnhVvXhccfcXAsBlrYPNmUOKJWiG7mcrje0ELSr1KPE69Q==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
+			"integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
 			"cpu": [
 				"arm64"
 			],
@@ -191,9 +191,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-darwin-x64": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.2.2.tgz",
-			"integrity": "sha512-PdIQidwQ4nUX/qNL0JXzSwNYadr+yX/Yoo+kZSCxBZqlAqug9SlKR/1H5EG5jSEpkEDRo2d1JdrO1W4kU6uNHw==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
+			"integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -207,9 +207,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.2.2.tgz",
-			"integrity": "sha512-5sZicPkJCoyxTEOW2he+u6UV97pTXY4c7fbHOZ/aslu9ewsunD0231QUBSvnjBB9hRFzzP2JRfNCLY+IvWfw0Q==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
+			"integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -226,9 +226,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.2.2.tgz",
-			"integrity": "sha512-Vto5fqRzMepQNJPeEhQLOIkmAoNbSBQNlpMe64OHTjEbAtQpJYVHEwe+8WJLaEGLA9qBksLv7ctiYPLLxgVVYQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
+			"integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -245,9 +245,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.2.2.tgz",
-			"integrity": "sha512-NJTTaUDU49WEJT+ImS9evlv3i3x42HN8PbcqdyydI9picnKtuf5TxRL94naoW09YDMYWpkrwVeVqaG7GTSIepQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
+			"integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
 			"cpu": [
 				"x64"
 			],
@@ -264,9 +264,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.2.2.tgz",
-			"integrity": "sha512-9nFdNDkWaU35bhWUIciDmi439W0fq2ZNgv1GCi2A/LSb+8vTw9l9z+fVW4YEn7Tlvbs8gyQkJvbc62ZD1H76xA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
+			"integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
 			"cpu": [
 				"x64"
 			],
@@ -283,25 +283,25 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.2.2.tgz",
-			"integrity": "sha512-3NWaxRc3KSwr9zHBEGcQ147rMgAhi/HzZWZJPRN2YLbtuLhoeBPruhdX1MIlOYAg3FvJPYdzGCAKvvWWU6pF0A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
+			"integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
 			"cpu": [
 				"wasm32"
 			],
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@napi-rs/wasm-runtime": "^1.1.5"
+				"@napi-rs/wasm-runtime": "^1.1.6"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.2.2.tgz",
-			"integrity": "sha512-QsyOgocLGOwDm8zAyuAiziALMzbTTevaqBLv5lvdhyhj2JC5yjp0H3yeEBtE0owRLr1gDQdX0+1qBSc5tTwp4g==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
+			"integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -315,9 +315,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.2.2.tgz",
-			"integrity": "sha512-+/C8Oh9YS8C0fwtaqDtUSPniKwlJqgiQbxp7XuzxCP0RI/Jf7yOlz9ZHNr6jD3ZJa4CHdq0mYq7pd8QFiNGIZA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
+			"integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
 			"cpu": [
 				"x64"
 			],
@@ -331,12 +331,15 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-rs": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.2.2.tgz",
-			"integrity": "sha512-C0qoz7Hxa2krlwMYfzQ1ZxOjR6cGmO+iskjRXXCdUM85W/cAPGTi/MSQlLkv0ADMz+Go1/lqeRBjL8AZwsFffQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
+			"integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/compiler-binding": "0.2.2"
+				"@astrojs/compiler-binding": "0.3.1"
+			},
+			"engines": {
+				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@astrojs/db": {
@@ -414,12 +417,12 @@
 			}
 		},
 		"node_modules/@astrojs/markdown-remark": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
-			"integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+			"integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.10.0",
+				"@astrojs/internal-helpers": "0.10.1",
 				"@astrojs/prism": "4.0.2",
 				"github-slugger": "^2.0.0",
 				"hast-util-from-html": "^2.0.3",
@@ -438,26 +441,59 @@
 				"vfile": "^6.0.3"
 			}
 		},
-		"node_modules/@astrojs/markdown-satteri": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz",
-			"integrity": "sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==",
+		"node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+			"integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.10.0",
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
+			}
+		},
+		"node_modules/@astrojs/markdown-satteri": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+			"integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/internal-helpers": "0.10.1",
 				"@astrojs/prism": "4.0.2",
 				"github-slugger": "^2.0.0",
+				"hast-util-from-html": "^2.0.3",
 				"satteri": "^0.9.1"
 			}
 		},
-		"node_modules/@astrojs/mdx": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.0.tgz",
-			"integrity": "sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==",
+		"node_modules/@astrojs/markdown-satteri/node_modules/@astrojs/internal-helpers": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+			"integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.10.0",
-				"@astrojs/markdown-remark": "7.2.0",
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
+			}
+		},
+		"node_modules/@astrojs/mdx": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
+			"integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/internal-helpers": "0.10.1",
+				"@astrojs/markdown-remark": "7.2.1",
 				"@mdx-js/mdx": "^3.1.1",
 				"acorn": "^8.16.0",
 				"es-module-lexer": "^2.0.0",
@@ -475,13 +511,29 @@
 				"node": ">=22.12.0"
 			},
 			"peerDependencies": {
-				"@astrojs/markdown-satteri": "^0.3.1-alpha.0",
-				"astro": "^7.0.0-alpha.0"
+				"@astrojs/markdown-satteri": "^0.3.1",
+				"astro": "^7.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@astrojs/markdown-satteri": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@astrojs/mdx/node_modules/@astrojs/internal-helpers": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+			"integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
 			}
 		},
 		"node_modules/@astrojs/partytown": {
@@ -507,12 +559,12 @@
 			}
 		},
 		"node_modules/@astrojs/react": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-6.0.0.tgz",
-			"integrity": "sha512-jNf3kKE6KYXJbD5ZsXaLhnwDK3YvK9ttQ2ykAcNf5XdxOlUQEHLnomO3FO8abqghs0ilqhgGOyc2AlgGyQtz/g==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-6.0.1.tgz",
+			"integrity": "sha512-Afs1sEm72P2plDnrOGxmIteJ7bjx/VqxlcaQLNip5eHJ5tIvKUORQetC9UKcvgwKnj51t60HWl5mOANkOsWs4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.10.0",
+				"@astrojs/internal-helpers": "0.10.1",
 				"@vitejs/plugin-react": "^5.2.0",
 				"devalue": "^5.8.1",
 				"ultrahtml": "^1.6.0",
@@ -526,6 +578,22 @@
 				"@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@astrojs/react/node_modules/@astrojs/internal-helpers": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+			"integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
 			}
 		},
 		"node_modules/@astrojs/rss": {
@@ -551,16 +619,15 @@
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
-			"integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+			"integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ci-info": "^4.4.0",
 				"dset": "^3.1.4",
 				"is-docker": "^4.0.0",
-				"is-wsl": "^3.1.1",
-				"which-pm-runs": "^1.1.0"
+				"package-manager-detector": "^1.6.0"
 			},
 			"engines": {
 				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
@@ -5270,13 +5337,13 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.2"
+				"@tybys/wasm-util": "^0.10.3"
 			},
 			"funding": {
 				"type": "github",
@@ -8352,9 +8419,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -11596,15 +11663,15 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-7.0.2.tgz",
-			"integrity": "sha512-Rj31HS85pVSfiQTxKTwH6vTmF8y57iRfkgb1uiCTtdLIh3jlUKPAPXtEmHXRKp/PdTS00D4EXYlWXypY+AVVCA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-7.1.2.tgz",
+			"integrity": "sha512-rn7bsh2n2/Wm/blS7QO6+aKstNfEOygX35cACGQJP8tM2uLRfeNTTEawrUR6NpVr27mOMGnl6CSWQ0CNb8iGZA==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/compiler-rs": "^0.2.2",
-				"@astrojs/internal-helpers": "0.10.0",
-				"@astrojs/markdown-satteri": "0.3.2",
-				"@astrojs/telemetry": "3.3.2",
+				"@astrojs/compiler-rs": "^0.3.1",
+				"@astrojs/internal-helpers": "0.10.1",
+				"@astrojs/markdown-satteri": "0.3.4",
+				"@astrojs/telemetry": "3.3.3",
 				"@capsizecss/unpack": "^4.0.0",
 				"@clack/prompts": "^1.1.0",
 				"@oslojs/encoding": "^1.1.0",
@@ -11615,7 +11682,7 @@
 				"ci-info": "^4.4.0",
 				"clsx": "^2.1.1",
 				"common-ancestor-path": "^2.0.0",
-				"cookie": "^1.1.1",
+				"cookie": "^2.0.1",
 				"devalue": "^5.8.1",
 				"diff": "^8.0.3",
 				"dset": "^3.1.4",
@@ -11632,14 +11699,13 @@
 				"magic-string": "^0.30.21",
 				"magicast": "^0.5.2",
 				"mrmime": "^2.0.1",
-				"neotraverse": "^0.6.18",
+				"neotraverse": "^1.0.1",
 				"obug": "^2.1.1",
 				"p-limit": "^7.3.0",
 				"p-queue": "^9.1.0",
 				"package-manager-detector": "^1.6.0",
 				"piccolore": "^0.1.3",
 				"picomatch": "^4.0.4",
-				"rehype": "^13.0.2",
 				"semver": "^7.7.4",
 				"shiki": "^4.0.2",
 				"smol-toml": "^1.6.0",
@@ -11649,9 +11715,7 @@
 				"tinyglobby": "^0.2.15",
 				"ultrahtml": "^1.6.0",
 				"unifont": "~0.7.4",
-				"unist-util-visit": "^5.1.0",
 				"unstorage": "^1.17.5",
-				"vfile": "^6.0.3",
 				"vite": "^8.0.13",
 				"vitefu": "^1.1.2",
 				"xxhash-wasm": "^1.1.0",
@@ -11671,10 +11735,10 @@
 				"url": "https://opencollective.com/astrodotbuild"
 			},
 			"optionalDependencies": {
-				"sharp": "^0.34.0"
+				"sharp": "^0.34.0 || ^0.35.0"
 			},
 			"peerDependencies": {
-				"@astrojs/markdown-remark": "7.2.0"
+				"@astrojs/markdown-remark": "7.2.1"
 			},
 			"peerDependenciesMeta": {
 				"@astrojs/markdown-remark": {
@@ -11832,6 +11896,22 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/astro/node_modules/@astrojs/internal-helpers": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+			"integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.4",
+				"@types/mdast": "^4.0.4",
+				"js-yaml": "^4.1.1",
+				"picomatch": "^4.0.4",
+				"retext-smartypants": "^6.2.0",
+				"shiki": "^4.0.2",
+				"smol-toml": "^1.6.0",
+				"unified": "^11.0.5"
 			}
 		},
 		"node_modules/astro/node_modules/@esbuild/aix-ppc64": {
@@ -13735,12 +13815,12 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+			"integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -22153,39 +22233,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/is-inside-container": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-docker": "^3.0.0"
-			},
-			"bin": {
-				"is-inside-container": "cli.js"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-inside-container/node_modules/is-docker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-			"license": "MIT",
-			"bin": {
-				"is-docker": "cli.js"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-installed-globally": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -22555,21 +22602,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-wsl": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-inside-container": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-yarn-global": {
@@ -26557,9 +26589,9 @@
 			}
 		},
 		"node_modules/neotraverse": {
-			"version": "0.6.18",
-			"resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-			"integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+			"integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
@@ -29876,37 +29908,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/rehype": {
-			"version": "13.0.2",
-			"resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-			"integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"rehype-parse": "^9.0.0",
-				"rehype-stringify": "^10.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/rehype-parse": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-			"integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"hast-util-from-html": "^2.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/rehype-raw": {
@@ -36812,15 +36813,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-pm-runs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-			"integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/which-typed-array": {

--- a/package.json
+++ b/package.json
@@ -67,17 +67,15 @@
 		"fallow:audit": "npx --yes fallow audit",
 		"fallow:fix": "npx --yes fallow fix --dry-run",
 		"// === Database ===": "",
-		"db:push": "drizzle-kit push",
-		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:seed": "npx astro db execute db/seed.ts --remote",
 		"db:studio": "astro db studio"
 	},
 	"dependencies": {
 		"@astrojs/db": "^0.21.3",
-		"@astrojs/mdx": "^7.0.0",
+		"@astrojs/mdx": "^7.0.3",
 		"@astrojs/partytown": "^2.1.7",
-		"@astrojs/react": "^6.0.0",
+		"@astrojs/react": "^6.0.1",
 		"@astrojs/rss": "^4.0.18",
 		"@astrojs/sitemap": "^3.7.3",
 		"@astrojs/vercel": "^11.0.0",
@@ -91,7 +89,7 @@
 		"@vercel/blob": "^2.4.1",
 		"@vercel/og": "^0.8.6",
 		"@vercel/speed-insights": "^2.0.0",
-		"astro": "^7.0.2",
+		"astro": "^7.1.2",
 		"astro-icon": "^1.1.5",
 		"astro-seo": "^0.8.4",
 		"drizzle-orm": "^0.45.2",
@@ -151,7 +149,8 @@
 		"web-vitals": "^5.0.3"
 	},
 	"overrides": {
-		"vite": "^7.3.2"
+		"vite": "^7.3.2",
+		"neotraverse": "^1.0.1"
 	},
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx,astro}": [

--- a/src/lib/blob.ts
+++ b/src/lib/blob.ts
@@ -1,0 +1,32 @@
+// Vercel Blob credential resolution.
+//
+// The store is private, so every operation needs valid credentials. On Vercel
+// the per-request `VERCEL_OIDC_TOKEN` is injected into `process.env` at
+// runtime — but Astro resolves `import.meta.env` at *build* time, so reading
+// the OIDC token from `import.meta.env` yields a stale/empty value and the API
+// rejects it with "Access denied". Prefer `process.env` (runtime) and fall
+// back to `import.meta.env` for local dev (.env.local).
+function fromEnv(
+	processValue: string | undefined,
+	buildValue: string | undefined,
+): string | undefined {
+	return processValue ?? buildValue
+}
+
+export function blobAuth(): {
+	token?: string
+	oidcToken?: string
+	storeId?: string
+} {
+	return {
+		token: fromEnv(
+			process.env.BLOB_READ_WRITE_TOKEN,
+			import.meta.env.BLOB_READ_WRITE_TOKEN,
+		),
+		oidcToken: fromEnv(
+			process.env.VERCEL_OIDC_TOKEN,
+			import.meta.env.VERCEL_OIDC_TOKEN,
+		),
+		storeId: fromEnv(process.env.BLOB_STORE_ID, import.meta.env.BLOB_STORE_ID),
+	}
+}

--- a/src/lib/clientFiles.ts
+++ b/src/lib/clientFiles.ts
@@ -1,22 +1,15 @@
+import { blobAuth } from '@lib/blob'
 import { db } from '@lib/db'
 import { del } from '@vercel/blob'
 import { and, eq } from 'drizzle-orm'
 
 import { clientNodes } from '@/db/schema'
 
-function blobOptions() {
-	return {
-		token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-		oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-		storeId: import.meta.env.BLOB_STORE_ID,
-	}
-}
-
 // Best-effort blob deletion: a storage failure must not orphan DB rows, so we
 // log and continue rather than throw.
 async function deleteBlob(blobKey: string): Promise<void> {
 	try {
-		await del(blobKey, blobOptions())
+		await del(blobKey, blobAuth())
 	} catch (error) {
 		console.error('[clientFiles] blob delete failed:', blobKey, error)
 	}

--- a/src/pages/api/admin/client-files.json.ts
+++ b/src/pages/api/admin/client-files.json.ts
@@ -1,3 +1,4 @@
+import { blobAuth } from '@lib/blob'
 import { deleteNodeRecursive } from '@lib/clientFiles'
 import { db } from '@lib/db'
 import {
@@ -81,9 +82,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 				// Private: client documents are confidential. Downloads are served
 				// via short-lived presigned URLs (see api/client/files.json.ts).
 				access: 'private',
-				token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-				oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-				storeId: import.meta.env.BLOB_STORE_ID,
+				...blobAuth(),
 				addRandomSuffix: false,
 			})
 

--- a/src/pages/api/client/files.json.ts
+++ b/src/pages/api/client/files.json.ts
@@ -1,3 +1,4 @@
+import { blobAuth } from '@lib/blob'
 import { requireClientSession } from '@lib/clientSession'
 import { db } from '@lib/db'
 import {
@@ -48,16 +49,12 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
 
 		// The store is private, so the blob URL isn't directly accessible.
 		// Issue a short-lived (1h) presigned GET URL scoped to this one file.
-		const blobAuth = {
-			token: import.meta.env.BLOB_READ_WRITE_TOKEN,
-			oidcToken: import.meta.env.VERCEL_OIDC_TOKEN,
-			storeId: import.meta.env.BLOB_STORE_ID,
-		}
+		const auth = blobAuth()
 
-		const { pathname } = await head(node.blobKey, blobAuth)
+		const { pathname } = await head(node.blobKey, auth)
 
 		const signedToken = await issueSignedToken({
-			...blobAuth,
+			...auth,
 			pathname,
 			operations: ['get'],
 			validUntil: Date.now() + 60 * 60 * 1000,


### PR DESCRIPTION
## Summary
- Bumps `astro` 7.0.2 → 7.1.2 (latest), plus matching `@astrojs/mdx` (7.0.3) and `@astrojs/react` (6.0.1) patch updates
- Fixes a latent `neotraverse` version conflict that broke prerendering after the bump

## Details
Astro's content layer depends on `neotraverse@1.x`, while `@textlint/markdown-to-ast` depends on `neotraverse@0.6.x`. npm was hoisting the older 0.6.18 to the top level, and since astro's built output does a bare `import { forEach } from 'neotraverse'` resolved at runtime, the build crashed with `The requested module 'neotraverse' does not provide an export named 'forEach'`. Pinned to `^1.0.1` via `package.json` `overrides`, the same pattern already used in this repo for the vite/rolldown version skew.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run test:critical` — 62/62 passing
- [x] `npm run build` — completes, prerendering succeeds